### PR TITLE
Fix broken or outdated token tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,12 +36,6 @@
             "node-releases": "^1.1.60"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001124",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz",
-          "integrity": "sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA==",
-          "dev": true
-        },
         "electron-to-chromium": {
           "version": "1.3.562",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.562.tgz",
@@ -445,12 +439,6 @@
             "escalade": "^3.0.2",
             "node-releases": "^1.1.60"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001124",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz",
-          "integrity": "sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA==",
-          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.3.562",
@@ -3437,12 +3425,6 @@
             "node-releases": "^1.1.60"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001124",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz",
-          "integrity": "sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA==",
-          "dev": true
-        },
         "electron-to-chromium": {
           "version": "1.3.562",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.562.tgz",
@@ -6251,6 +6233,12 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
+    "caniuse-lite": {
+      "version": "1.0.30001207",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz",
+      "integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw==",
+      "dev": true
+    },
     "capture-exit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -6715,12 +6703,6 @@
             "escalade": "^3.0.2",
             "node-releases": "^1.1.60"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001124",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz",
-          "integrity": "sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA==",
-          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.3.562",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "docs:lint": "documentation lint ./src/**",
     "lint": "eslint --ignore-path .gitignore --ignore-pattern lib .",
     "test": "jest",
-    "test:debugger": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "test:watch": "npm run test -- --watch"
   },
   "devDependencies": {

--- a/test/activity.test.js
+++ b/test/activity.test.js
@@ -67,6 +67,7 @@ describe('Activity', () => {
     });
 
     await loop(
+      'Wait for graph to index latest activities',
       () => {
         return core.activity.getLatest(account, {
           safeAddress,
@@ -126,6 +127,7 @@ describe('Activity', () => {
     let activity;
 
     const latest = await loop(
+      'Wait for the graph to index activity of newly added Safe owner',
       () => {
         return core.activity.getLatest(account, {
           safeAddress,

--- a/test/helpers/loop.js
+++ b/test/helpers/loop.js
@@ -1,4 +1,5 @@
 const LOOP_INTERVAL = 1000;
+const MAX_ATTEMPTS = 60;
 
 export function isContractDeployed(code) {
   return code !== '0x';
@@ -21,15 +22,27 @@ export async function getTrustConnection(
   return network.find((item) => item.safeAddress === otherSafeAddress);
 }
 
-export default async function loop(request, condition = isContractDeployed) {
+export default async function loop(
+  label,
+  request,
+  condition = isContractDeployed,
+) {
   return new Promise((resolve, reject) => {
+    let attempt = 0;
+
     const interval = setInterval(async () => {
       try {
         const response = await request();
 
+        attempt += 1;
+
         if (condition(response)) {
           clearInterval(interval);
           resolve(response);
+        } else if (attempt > MAX_ATTEMPTS) {
+          throw new Error(
+            `Tried too many times waiting for condition "${label}"`,
+          );
         }
       } catch (error) {
         clearInterval(interval);

--- a/test/helpers/transactions.js
+++ b/test/helpers/transactions.js
@@ -29,7 +29,9 @@ export async function deploySafe(core, account) {
     safeAddress,
   });
 
-  await loop(() => web3.eth.getCode(safeAddress));
+  await loop(`Wait until Safe ${safeAddress} got deployed`, () =>
+    web3.eth.getCode(safeAddress),
+  );
 
   return safeAddress;
 }
@@ -55,14 +57,18 @@ export async function deploySafeAndToken(core, account) {
 export async function addTrustConnection(core, account, userOptions) {
   const transactionHash = await core.trust.addConnection(account, userOptions);
 
-  await loop(() => {
-    return getTrustConnection(
-      core,
-      account,
-      userOptions.canSendTo,
-      userOptions.user,
-    );
-  }, isReady);
+  await loop(
+    `Wait for trust connection between ${userOptions.canSendTo} and ${userOptions.user} to show up in the Graph`,
+    () => {
+      return getTrustConnection(
+        core,
+        account,
+        userOptions.canSendTo,
+        userOptions.user,
+      );
+    },
+    isReady,
+  );
 
   return transactionHash;
 }
@@ -71,6 +77,7 @@ export async function addSafeOwner(core, account, userOptions) {
   const transactionHash = await core.safe.addOwner(account, userOptions);
 
   await loop(
+    'Wait for newly added address to be listed as Safe owner',
     () => {
       return core.safe.getOwners(account, {
         safeAddress: userOptions.safeAddress,

--- a/test/organization.test.js
+++ b/test/organization.test.js
@@ -27,11 +27,14 @@ describe('Organization', () => {
       safeAddress,
     });
 
-    await loop(() => web3.eth.getCode(safeAddress));
+    await loop('Wait until Safe for organization got deployed', () =>
+      web3.eth.getCode(safeAddress),
+    );
   });
 
   it('should check if safe has enough funds for organization to be created', async () => {
     const value = await loop(
+      'Wait for organization to be funded',
       async () => {
         return await core.organization.isFunded(account, {
           safeAddress,
@@ -79,6 +82,7 @@ describe('Organization', () => {
     );
 
     const result = await loop(
+      'Wait for organization to own some ether',
       async () => {
         return await core.token.listAllTokens(account, {
           safeAddress,

--- a/test/safe.test.js
+++ b/test/safe.test.js
@@ -81,7 +81,9 @@ describe('Safe', () => {
       });
 
       // .. wait for Relayer to really deploy Safe
-      await loop(() => web3.eth.getCode(safeAddress));
+      await loop('Wait until Safe got deployed', () =>
+        web3.eth.getCode(safeAddress),
+      );
 
       // Deploy Token as well to pay our fees later
       await core.token.deploy(accounts[0], {
@@ -151,7 +153,9 @@ describe('Safe', () => {
       });
 
       // .. wait for Relayer to really deploy Safe
-      await loop(() => web3.eth.getCode(safeAddress));
+      await loop('Wait until Safe got deployed', () =>
+        web3.eth.getCode(safeAddress),
+      );
 
       // Deploy Token
       await core.token.deploy(accounts[0], {
@@ -202,6 +206,7 @@ describe('Safe', () => {
       expect(owners.length).toBe(2);
 
       await loop(
+        'Wait for newly added address to show up as Safe owner',
         () => {
           return core.safe.getAddresses(accounts[0], {
             ownerAddress: accounts[1].address,

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -190,8 +190,8 @@ describe('Token', () => {
         safeAddress: safeAddresses[5],
       });
 
-      // It should be equals the initial UBI payout
-      // which was set during Hub contract deployment:
+      // It should be equals the initial UBI payout which was set during Hub
+      // contract deployment:
       expect(balance).toMatchObject(
         new web3.utils.BN(core.utils.toFreckles(100)),
       );
@@ -250,7 +250,7 @@ describe('Token', () => {
     });
 
     it('should fail sending Circles when there is no path', async () => {
-      // Max flow is smaller than the given transfer value.
+      // Max flow is smaller than the given transfer value
       await expect(
         core.token.transfer(accounts[0], {
           from: safeAddresses[0],
@@ -259,8 +259,7 @@ describe('Token', () => {
         }),
       ).rejects.toThrow();
 
-      // Trust connection does not exist between
-      // node 0 and 5
+      // Trust connection does not exist between node 0 and 5
       await expect(
         core.token.transfer(accounts[0], {
           from: safeAddresses[0],

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -138,19 +138,6 @@ describe('Token', () => {
       safeAddresses = result.safeAddresses;
     });
 
-    it('should return empty path when no transfer is possible', async () => {
-      const value = new web3.utils.BN(core.utils.toFreckles(100));
-
-      const result = await core.token.findTransitiveTransfer(accounts[0], {
-        from: safeAddresses[0],
-        to: safeAddresses[4],
-        value,
-      });
-
-      expect(result.transferSteps.length).toBe(0);
-      expect(result.maxFlowValue).toBe(25);
-    });
-
     it('should return max flow and possible path', async () => {
       const value = new web3.utils.BN(core.utils.toFreckles(1));
 

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -32,11 +32,10 @@ async function deployTestNetwork(
   connections = TEST_TRUST_NETWORK,
 ) {
   // Deploy Safe and Token for each test account
-  const tasks = accounts.map((account) => {
-    return deploySafeAndToken(core, account);
-  });
-
-  const results = await Promise.all(tasks);
+  let results = [];
+  for (const account of accounts) {
+    results.push(await deploySafeAndToken(core, account));
+  }
 
   const safeAddresses = [];
   const tokenAddresses = [];

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -150,15 +150,18 @@ describe('Token', () => {
       expect(result.transferSteps.length).toBe(2);
 
       expect(result.transferSteps[0].from).toBe(safeAddresses[0]);
-      expect(result.transferSteps[0].to).toBe(safeAddresses[3]);
-      expect(result.transferSteps[0].value).toBe(1);
+      expect(result.transferSteps[0].to).toBe(safeAddresses[1]);
+      expect(result.transferSteps[0].value).toBe(core.utils.toFreckles(1));
       expect(result.transferSteps[0].tokenOwnerAddress).toBe(safeAddresses[0]);
-      expect(result.transferSteps[1].from).toBe(safeAddresses[3]);
+      expect(result.transferSteps[1].from).toBe(safeAddresses[1]);
       expect(result.transferSteps[1].to).toBe(safeAddresses[4]);
-      expect(result.transferSteps[1].value).toBe(1);
-      expect(result.transferSteps[1].tokenOwnerAddress).toBe(safeAddresses[3]);
+      expect(result.transferSteps[1].value).toBe(core.utils.toFreckles(1));
+      expect(result.transferSteps[1].tokenOwnerAddress).toBe(safeAddresses[1]);
 
-      expect(result.maxFlowValue).toBe(25);
+      // The `pathfinder` stops searching for max flow as soon as it found a
+      // successful solution, therefore it returns a lower max flow than it
+      // actually is (25).
+      expect(result.maxFlowValue).toBe(core.utils.toFreckles(1));
     });
   });
 

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -1,4 +1,6 @@
 import { getTokenContract } from '~/common/getContracts';
+import getContracts from '~/common/getContracts';
+import { ZERO_ADDRESS } from '~/common/constants';
 
 import createCore from './helpers/core';
 import getAccount from './helpers/account';
@@ -65,6 +67,9 @@ async function deployTestNetwork(
 describe('Token', () => {
   let core;
   let accounts;
+  let signupBonus;
+  let contracts;
+  let hubAddress;
 
   beforeAll(async () => {
     accounts = new Array(6).fill({}).map((item, index) => {
@@ -72,6 +77,16 @@ describe('Token', () => {
     });
 
     core = createCore();
+
+    // Retrieve the value of the initial UBI payout (called signupBonus) from the deployed Hub contract
+    hubAddress = core.options.hubAddress;
+    contracts = await getContracts(web3, {
+      hubAddress: hubAddress,
+      proxyFactoryAddress: ZERO_ADDRESS,
+      safeMasterAddress: ZERO_ADDRESS,
+    });
+    const { hub } = contracts;
+    signupBonus = await hub.methods.signupBonus().call();
   });
 
   it('should check if safe has enough funds for token to be deployed', async () => {
@@ -180,10 +195,10 @@ describe('Token', () => {
         safeAddress: safeAddresses[5],
       });
 
-      // It should be equals the initial UBI payout which was set during Hub
+      // It should be equals the initial UBI payout (called signupBonus) which was set during Hub
       // contract deployment:
       expect(balance).toMatchObject(
-        new web3.utils.BN(core.utils.toFreckles(100)),
+        new web3.utils.BN(signupBonus),
       );
     });
 

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -197,9 +197,7 @@ describe('Token', () => {
 
       // It should be equals the initial UBI payout (called signupBonus) which was set during Hub
       // contract deployment:
-      expect(balance).toMatchObject(
-        new web3.utils.BN(signupBonus),
-      );
+      expect(balance).toMatchObject(new web3.utils.BN(signupBonus));
     });
 
     it('should send Circles to someone directly', async () => {
@@ -233,6 +231,7 @@ describe('Token', () => {
       expect(web3.utils.isHexStrict(response)).toBe(true);
 
       const accountBalance = await loop(
+        'Wait for balance to be lower after user transferred Circles',
         () => {
           return core.token.getBalance(accounts[indexFrom], {
             safeAddress: safeAddresses[indexFrom],

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -187,6 +187,7 @@ describe('Token', () => {
       const result = await deployTestNetwork(core, accounts);
       safeAddresses = result.safeAddresses;
       tokenAddresses = result.tokenAddresses;
+
     });
 
     it('should get the current balance', async () => {
@@ -217,7 +218,8 @@ describe('Token', () => {
     });
 
     it('should send Circles to someone transitively', async () => {
-      const value = web3.utils.toBN(core.utils.toFreckles(5));
+      const sentCircles = 5;
+      const value = web3.utils.toBN(core.utils.toFreckles(sentCircles));
       const indexFrom = 0;
       const indexTo = 4;
 
@@ -237,7 +239,10 @@ describe('Token', () => {
           });
         },
         (balance) => {
-          return balance.toString().slice(0, 2) === '94';
+          return (
+            (core.utils.fromFreckles(balance) + 1).toString() ===
+            (core.utils.fromFreckles(signupBonus) - sentCircles).toString()
+          );
         },
       );
 
@@ -248,8 +253,12 @@ describe('Token', () => {
         },
       );
 
-      expect(otherAccountBalance.toString().slice(0, 3)).toBe('104');
-      expect(accountBalance.toString().slice(0, 2)).toBe('94');
+      expect(
+        (core.utils.fromFreckles(otherAccountBalance) + 1).toString()
+      ).toBe((core.utils.fromFreckles(signupBonus) + sentCircles).toString());
+      expect((core.utils.fromFreckles(accountBalance) + 1).toString()).toBe(
+        (core.utils.fromFreckles(signupBonus) - sentCircles).toString(),
+      );
     });
 
     it('should fail sending Circles when there is no path', async () => {

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -202,11 +202,11 @@ describe('Token', () => {
     it('should send Circles to someone directly', async () => {
       const value = web3.utils.toBN(core.utils.toFreckles(5));
 
-      // Unidirectional trust relationship from 2 to 5
-      const indexFrom = 5;
+      // Unidirectional trust relationship from 1 to 2
+      const indexFrom = 1;
       const indexTo = 2;
 
-      // Transfer from 5 to 2
+      // Transfer from 1 to 2
       const response = await core.token.transfer(accounts[indexFrom], {
         from: safeAddresses[indexFrom],
         to: safeAddresses[indexTo],

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -187,7 +187,6 @@ describe('Token', () => {
       const result = await deployTestNetwork(core, accounts);
       safeAddresses = result.safeAddresses;
       tokenAddresses = result.tokenAddresses;
-
     });
 
     it('should get the current balance', async () => {
@@ -254,7 +253,7 @@ describe('Token', () => {
       );
 
       expect(
-        (core.utils.fromFreckles(otherAccountBalance) + 1).toString()
+        (core.utils.fromFreckles(otherAccountBalance) + 1).toString(),
       ).toBe((core.utils.fromFreckles(signupBonus) + sentCircles).toString());
       expect((core.utils.fromFreckles(accountBalance) + 1).toString()).toBe(
         (core.utils.fromFreckles(signupBonus) - sentCircles).toString(),

--- a/test/trust.test.js
+++ b/test/trust.test.js
@@ -36,9 +36,13 @@ describe('Trust', () => {
 
     expect(web3.utils.isHexStrict(response)).toBe(true);
 
-    const connection = await loop(() => {
-      return getTrustConnection(core, account, safeAddress, otherSafeAddress);
-    }, isReady);
+    const connection = await loop(
+      'Wait for the graph to index newly added trust connection',
+      () => {
+        return getTrustConnection(core, account, safeAddress, otherSafeAddress);
+      },
+      isReady,
+    );
 
     expect(connection.safeAddress).toBe(otherSafeAddress);
     expect(connection.isIncoming).toBe(true);
@@ -46,14 +50,18 @@ describe('Trust', () => {
     expect(connection.limitPercentageIn).toBe(44);
     expect(connection.limitPercentageOut).toBe(0);
 
-    let otherConnection = await loop(() => {
-      return getTrustConnection(
-        core,
-        otherAccount,
-        otherSafeAddress,
-        safeAddress,
-      );
-    }, isReady);
+    let otherConnection = await loop(
+      'Wait for trust connection to be indexed by the graph',
+      () => {
+        return getTrustConnection(
+          core,
+          otherAccount,
+          otherSafeAddress,
+          safeAddress,
+        );
+      },
+      isReady,
+    );
 
     expect(otherConnection.safeAddress).toBe(safeAddress);
     expect(otherConnection.isIncoming).toBe(false);
@@ -69,6 +77,7 @@ describe('Trust', () => {
     });
 
     otherConnection = await loop(
+      'Wait for trust connection to be indexed by the Graph',
       () => {
         return getTrustConnection(
           core,
@@ -122,6 +131,7 @@ describe('Trust', () => {
     });
 
     const network = await loop(
+      'Wait for trust network to be empty after untrusting user',
       async () => {
         return await core.trust.getNetwork(account, {
           safeAddress,


### PR DESCRIPTION
**Todos:**

* [x] Check if `circles-core` tests pass against latest `circles-api` version 
* [x] Fix `Token > Transitive Transactions > should send Circles to someone transitively`
  Initial payout got changed in Circles contracts
* [x] Fix `Token > Transitive Transactions > should get the current balance`
  Initial payout got changed in Circles contracts
* [x] Fix `Token › Find transitive transfer steps › should return empty path when no transfer is possible`
  The new `pathfinder` executable behaves slightly different now and returns already transfer steps as soon as a max flow is given (unlike in the past where it returned an empty array). We deleted the test as it was testing a case which is not implemented anymore in the `pathfinder`. Also, we test against the expected invalid transfer in another test already.
* [x] Fix `Token › Find transitive transfer steps › should return max flow and possible path`
  The new `pathfinder` simply just comes up with a different transfer solution here. We just need to change the expected outcome.
* [x] Fix `Token › Transitive Transactions › should fail sending Circles when there is no path`
   This one is actually NOT broken! The pathfinder and the core works as expected, but the `circles-api` itself is generating wrong trust network data in the `edges.json`! In this case there is a bug somewhere in how the `edges.json` file gets build in the api. This should be fixed by refactoring the indexing algorithm in the api, see https://github.com/CirclesUBI/circles-api/pull/24