### PR TITLE
Fix broken GH action to deploy documentation website

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,9 +14,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Node
-        uses: actions/setup-node@v2.1.0
+        uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '12'
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
To fix a security issue with github actions we're updating to the latest
version: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Closing: https://github.com/CirclesUBI/circles-core/issues/62