### PR TITLE
Fix trust limits as an organization

### DIFF
--- a/src/trust.js
+++ b/src/trust.js
@@ -1,7 +1,9 @@
 import checkAccount from '~/common/checkAccount';
 import checkOptions from '~/common/checkOptions';
 
-const DEFAULT_LIMIT_PERCENTAGE = 50;
+const DEFAULT_USER_LIMIT_PERCENTAGE = 50;
+const DEFAULT_ORG_LIMIT_PERCENTAGE = 100;
+
 const DEFAULT_TRUST_LIMIT = 3;
 const NO_LIMIT_PERCENTAGE = 0;
 
@@ -275,9 +277,17 @@ export default function createTrustModule(web3, contracts, utils) {
         },
         limitPercentage: {
           type: 'number',
-          default: DEFAULT_LIMIT_PERCENTAGE,
+          default: DEFAULT_USER_LIMIT_PERCENTAGE,
         },
       });
+
+      const isOrgSignedup = await hub.methods
+        .organizations(options.canSendTo)
+        .call();
+
+      if (isOrgSignedup) {
+        options.limitPercentage = DEFAULT_ORG_LIMIT_PERCENTAGE;
+      }
 
       const txData = await hub.methods
         .trust(options.user, options.limitPercentage)

--- a/test/organization.test.js
+++ b/test/organization.test.js
@@ -6,12 +6,15 @@ import { deploySafeAndToken } from './helpers/transactions';
 
 describe('Organization', () => {
   let account;
+  let otherAccount;
   let core;
   let safeAddress;
   let userSafeAddress;
+  let otherUserSafeAddress;
 
   beforeAll(async () => {
     account = getAccount(0);
+    otherAccount = getAccount(1);
     core = createCore();
 
     // First deploy users Safe ..
@@ -30,6 +33,10 @@ describe('Organization', () => {
     await loop('Wait until Safe for organization got deployed', () =>
       web3.eth.getCode(safeAddress),
     );
+
+    // Then deploy other users Safe .. to test trust connections
+    const otherUser = await deploySafeAndToken(core, otherAccount);
+    otherUserSafeAddress = otherUser.safeAddress;
   });
 
   it('should check if safe has enough funds for organization to be created', async () => {
@@ -100,6 +107,16 @@ describe('Organization', () => {
     const txHash = await core.safe.addOwner(account, {
       safeAddress,
       ownerAddress: web3.utils.toChecksumAddress(web3.utils.randomHex(20)),
+    });
+
+    expect(web3.utils.isHexStrict(txHash)).toBe(true);
+  });
+
+  it('should be able to trust a user as an organization', async () => {
+    const txHash = await core.trust.addConnection(account, {
+      user: otherUserSafeAddress,
+      canSendTo: safeAddress,
+      limitPercentage: 44,
     });
 
     expect(web3.utils.isHexStrict(txHash)).toBe(true);


### PR DESCRIPTION
When the Safe that is the origin of a trust is an Organization, the trustLimit of this connection must be 100, ignoring any userOptions.