### PR TITLE
Return errors in requestGraph

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -134,7 +134,7 @@ async function requestGraph(endpoint, subgraphName, userOptions) {
     isTrailingSlash: false,
   });
 
-  return response.data;
+  return response.data || response.errors;
 }
 
 async function estimateTransactionCosts(
@@ -418,6 +418,8 @@ export default function createUtilsModule(web3, contracts, globalOptions) {
      * @param {Object} userOptions - query options
      * @param {string} userOptions.query - GraphQL query
      * @param {Object} userOptions.variables - GraphQL variables
+     *
+     * @return {Oject} - Object containing a list of objects or a lis of error messages
      */
     requestGraph: async (userOptions) => {
       return requestGraph(graphNodeEndpoint, subgraphName, userOptions);


### PR DESCRIPTION
The errors from the graph queries are not propagated. We want them for debugging purposes.