### PR TITLE
Stop using the relayer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,6 @@ export default class CirclesCore {
    * @param {string} options.graphNodeEndpoint - URL of the graph node
    * @param {string} options.hubAddress - address of deployed Circles Hub contract
    * @param {string} options.proxyFactoryAddress - address of deployed Gnosis ProxyFactory contract
-   * @param {string} options.relayServiceEndpoint - URL of the Relayer server
    * @param {string} options.safeMasterAddress - address of deployed Gnosis Safe master copy contract
    */
   constructor(web3, options) {


### PR DESCRIPTION
We are looking at which parts of the code call the relayer and for what. Later we can design different solutions (without relayer) for those same tasks, and reimplement the functions.

Here there are the function we need to reimplement:
- `safe.js` > `predictAddress()`
- `safe.js` > `getSafeStatus()`

If we stop using the relayer's database we will have to adjust our resources (rpc endpoints) to be able to deal with more eth_calls.