### PR TITLE
Add handling of hops input to findTransitiveTransfer

### DIFF
--- a/src/token.js
+++ b/src/token.js
@@ -24,6 +24,7 @@ const MAX_TRANSFER_STEPS = 52;
  * @param {string} userOptions.from - sender Safe address
  * @param {string} userOptions.to - receiver Safe address
  * @param {BN} userOptions.value - value of Circles tokens
+ * @param {number} userOptions.hops - maximum number of trust hops away from them sending user inside the trust network for finding transaction steps
  *
  * @return {Object[]} - transaction steps
  */
@@ -74,6 +75,7 @@ export async function findTransitiveTransfer(web3, utils, userOptions) {
  * @param {string} userOptions.from - sender Safe address
  * @param {string} userOptions.to - receiver Safe address
  * @param {BN} userOptions.value - value of Circles tokens
+ * @param {number} userOptions.hops - maximum number of trust hops away from them sending user inside the trust network for finding transaction steps
  *
  * @return {boolean} - steps are updated
  */
@@ -361,6 +363,7 @@ export default function createTokenModule(web3, contracts, utils) {
      * @param {string} userOptions.from - sender Safe address
      * @param {string} userOptions.to - receiver Safe address
      * @param {BN} userOptions.value - value for transactions path
+     * @param {number} userOptions.hops - maximum number of trust hops away from them sending user inside the trust network for finding transaction steps
      *
      * @return {boolean} - steps are updated
      */
@@ -380,6 +383,7 @@ export default function createTokenModule(web3, contracts, utils) {
      * @param {string} userOptions.to - receiver address
      * @param {BN} userOptions.value - value
      * @param {string} userOptions.paymentNote - optional payment note stored in API
+     * @param {number} userOptions.hops - maximum number of trust hops away from them sending user inside the trust network for finding transaction steps
      *
      * @return {string} - transaction hash
      */

--- a/src/token.js
+++ b/src/token.js
@@ -400,6 +400,10 @@ export default function createTokenModule(web3, contracts, utils) {
           type: 'string',
           default: '',
         },
+        hops: {
+          type: 'number',
+          default: 3,
+        },
       });
 
       const transfer = {

--- a/src/token.js
+++ b/src/token.js
@@ -88,6 +88,10 @@ export async function updateTransitiveTransfer(web3, utils, userOptions) {
     value: {
       type: web3.utils.isBN,
     },
+    hops: {
+      type: 'number',
+      default: 3,
+    },
   });
 
   try {
@@ -98,6 +102,7 @@ export async function updateTransitiveTransfer(web3, utils, userOptions) {
         from: options.from,
         to: options.to,
         value: options.value.toString(),
+        hops: options.value.toString(),
       },
     });
 

--- a/src/token.js
+++ b/src/token.js
@@ -102,7 +102,7 @@ export async function updateTransitiveTransfer(web3, utils, userOptions) {
         from: options.from,
         to: options.to,
         value: options.value.toString(),
-        hops: options.value.toString(),
+        hops: options.hops.toString(),
       },
     });
 

--- a/src/token.js
+++ b/src/token.js
@@ -38,6 +38,10 @@ export async function findTransitiveTransfer(web3, utils, userOptions) {
     value: {
       type: web3.utils.isBN,
     },
+    hops: {
+      type: 'number',
+      default: 3,
+    },
   });
 
   try {
@@ -48,6 +52,7 @@ export async function findTransitiveTransfer(web3, utils, userOptions) {
         from: options.from,
         to: options.to,
         value: options.value.toString(),
+        hops: options.hops.toString(),
       },
     });
 

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -184,7 +184,7 @@ describe('Token', () => {
       expect(result.maxFlowValue).toBe(core.utils.toFreckles(1));
     });
 
-    it('should return max flow and possible path with hops parameter', async () => {
+    it('should return max flow and possible path when using hops parameter', async () => {
       const value = new web3.utils.BN(core.utils.toFreckles(1));
 
       const result = await core.token.findTransitiveTransfer(accounts[0], {
@@ -209,7 +209,7 @@ describe('Token', () => {
       expect(result.maxFlowValue).toBe(core.utils.toFreckles(1));
     });
 
-    it('should return max flow and possible path with hops parameter', async () => {
+    it('should return 0 max flow and no path when using too low hops parameter', async () => {
       const value = new web3.utils.BN(core.utils.toFreckles(1));
 
       const result = await core.token.findTransitiveTransfer(accounts[0], {
@@ -308,22 +308,6 @@ describe('Token', () => {
       );
     });
 
-    it('should fail to send Circles to someone transitively if hops is too low to find a path', async () => {
-      const sentCircles = 5;
-      const value = web3.utils.toBN(core.utils.toFreckles(sentCircles));
-      const indexFrom = 0;
-      const indexTo = 4;
-
-      await expect(
-        core.token.transfer(accounts[indexFrom], {
-          from: safeAddresses[indexFrom],
-          to: safeAddresses[indexTo],
-          value,
-          hops: 1,
-        }),
-      ).rejects.toThrow();
-    });
-
     it('should fail sending Circles when maxflow is lower than requested transfer value', async () => {
       await expect(
         core.token.transfer(accounts[0], {
@@ -417,6 +401,17 @@ describe('Token', () => {
 
         // Do not check for the exact amount as payout is changing every second
         expect(web3.utils.toBN(balanceAfter).gt(expectedBalance)).toBe(true);
+      });
+    
+      it('should fail to send Circles to someone transitively if hops are too few to find a path', async () => {
+        await expect(
+          core.token.transfer(accounts[0], {
+            from: safeAddresses[0],
+            to: safeAddresses[4],
+            value: web3.utils.toBN(core.utils.toFreckles(5)),
+            hops: 1,
+          }),
+        ).rejects.toThrow();
       });
     });
   });

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -183,6 +183,31 @@ describe('Token', () => {
       // actually is (25).
       expect(result.maxFlowValue).toBe(core.utils.toFreckles(1));
     });
+
+    it('should return max flow and possible path with hops parameter', async () => {
+      const value = new web3.utils.BN(core.utils.toFreckles(1));
+
+      const result = await core.token.findTransitiveTransfer(accounts[0], {
+        from: safeAddresses[0],
+        to: safeAddresses[4],
+        value,
+        hops: '2',
+      });
+      expect(result.transferSteps.length).toBe(2);
+      expect(result.transferSteps[0].from).toBe(safeAddresses[0]);
+      expect(result.transferSteps[0].to).toBe(safeAddresses[3]);
+      expect(result.transferSteps[0].value).toBe(core.utils.toFreckles(1));
+      expect(result.transferSteps[0].tokenOwnerAddress).toBe(safeAddresses[0]);
+      expect(result.transferSteps[1].from).toBe(safeAddresses[3]);
+      expect(result.transferSteps[1].to).toBe(safeAddresses[4]);
+      expect(result.transferSteps[1].value).toBe(core.utils.toFreckles(1));
+      expect(result.transferSteps[1].tokenOwnerAddress).toBe(safeAddresses[3]);
+
+      // The `pathfinder` stops searching for max flow as soon as it found a
+      // successful solution, therefore it returns a lower max flow than it
+      // actually is (25).
+      expect(result.maxFlowValue).toBe(core.utils.toFreckles(1));
+    });
   });
 
   describe('Transitive Transactions', () => {

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -329,6 +329,17 @@ describe('Token', () => {
       ).rejects.toThrow();
     });
 
+    it('should fail to send Circles to someone transitively if hops are too few to find a path', async () => {
+      await expect(
+        core.token.transfer(accounts[0], {
+          from: safeAddresses[0],
+          to: safeAddresses[4],
+          value: web3.utils.toBN(core.utils.toFreckles(5)),
+          hops: 1,
+        }),
+      ).rejects.toThrow();
+    });
+
     it('should fail sending Circles when data error', async () => {
       // Update the edges.csv file simulating data error:
       // Direct path does not exist between safeAddress 0 and 4,
@@ -401,17 +412,6 @@ describe('Token', () => {
 
         // Do not check for the exact amount as payout is changing every second
         expect(web3.utils.toBN(balanceAfter).gt(expectedBalance)).toBe(true);
-      });
-
-      it('should fail to send Circles to someone transitively if hops are too few to find a path', async () => {
-        await expect(
-          core.token.transfer(accounts[0], {
-            from: safeAddresses[0],
-            to: safeAddresses[4],
-            value: web3.utils.toBN(core.utils.toFreckles(5)),
-            hops: 1,
-          }),
-        ).rejects.toThrow();
       });
     });
   });

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -402,7 +402,7 @@ describe('Token', () => {
         // Do not check for the exact amount as payout is changing every second
         expect(web3.utils.toBN(balanceAfter).gt(expectedBalance)).toBe(true);
       });
-    
+
       it('should fail to send Circles to someone transitively if hops are too few to find a path', async () => {
         await expect(
           core.token.transfer(accounts[0], {


### PR DESCRIPTION
Add the option to pass on "hops" to the API transfer request when using findTransitiveTransfer()

Needed for myxo issue: https://github.com/CirclesUBI/circles-myxogastria/issues/580