### PR TITLE
Typed data execute safe tx

### DIFF
--- a/src/token.js
+++ b/src/token.js
@@ -1,9 +1,10 @@
-import { ZERO_ADDRESS } from '~/common/constants';
+import { SAFE_LAST_VERSION, ZERO_ADDRESS } from '~/common/constants';
 
 import CoreError, { TransferError, ErrorCodes } from '~/common/error';
 import checkAccount from '~/common/checkAccount';
 import checkOptions from '~/common/checkOptions';
 import { getTokenContract } from '~/common/getContracts';
+import { getVersion } from '~/safe';
 
 /* Due to block gas limit of 12.500.000 a transitive transaction can have a
  * limited number of steps. The limit below gives a 50% buffer between the
@@ -225,11 +226,14 @@ export default function createTokenModule(web3, contracts, utils) {
 
       const txData = await hub.methods.signup().encodeABI();
 
+      const safeVersion = await getVersion(web3, options.safeAddress);
+
       // Call method and return result
       return await utils.executeSafeTx(account, {
         safeAddress: options.safeAddress,
         to: hub.options.address,
         txData,
+        isCRCVersion: safeVersion != SAFE_LAST_VERSION,
       });
     },
 

--- a/test/safe.test.js
+++ b/test/safe.test.js
@@ -7,15 +7,10 @@ import {
   deploySafeAndToken,
   fundSafe,
   deployCRCVersionSafe,
-  deployCRCVersionToken,
+  deployToken,
 } from './helpers/transactions';
 
-import {
-  SAFE_LAST_VERSION,
-  SAFE_CRC_VERSION,
-  ZERO_ADDRESS,
-} from '~/common/constants';
-import getContracts from '~/common/getContracts';
+import { SAFE_LAST_VERSION, SAFE_CRC_VERSION } from '~/common/constants';
 
 describe('Safe', () => {
   let core;
@@ -247,33 +242,20 @@ describe('Safe', () => {
     let ownerCRCVersion;
     let CRCVersionSafeAddress;
     let CRCVersionSafeInstance;
-    let contracts;
 
     beforeAll(async () => {
       // Deploy new version (v1.3.0)
       const result = await deploySafeAndToken(core, accounts[0]);
       safeAddress = result.safeAddress;
 
-      // Get the hub
-      const hubAddress = core.options.hubAddress;
-      contracts = await getContracts(web3, {
-        hubAddress: hubAddress,
-        proxyFactoryAddress: ZERO_ADDRESS,
-        safeMasterAddress: ZERO_ADDRESS,
-      });
-      const { hub } = contracts;
-
       // Deploy a Safe with the CRC version (v1.1.1+Circles)
       ownerCRCVersion = getAccount(8);
       CRCVersionSafeInstance = await deployCRCVersionSafe(ownerCRCVersion);
       CRCVersionSafeAddress = CRCVersionSafeInstance.options.address;
       await fundSafe(accounts[0], CRCVersionSafeAddress);
-      await deployCRCVersionToken(
-        web3,
-        ownerCRCVersion,
-        CRCVersionSafeInstance,
-        hub,
-      );
+      await deployToken(core, ownerCRCVersion, {
+        safeAddress: CRCVersionSafeAddress,
+      });
     });
 
     it('I should get the last version by default', async () => {


### PR DESCRIPTION
Some accounts cannot be created if they started the onboarding before we changed the full compatibility of Safe v1.3.0 was live (https://github.com/CirclesUBI/circles-myxogastria/releases/tag/v2.4.0). The problem lies in the relayer registering the old master copy address.
With this PR we fix the issue by allowing the `token.deploy` method to check the safe version and format the data acordingly.

Closes https://github.com/CirclesUBI/safe-relay-service/issues/72