### PR TITLE
Remove attempting to send the source token before pathfinder call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ export default class CirclesCore {
          * gas estimate and the block gas limit.
          * For more information, see the Circles handbook.
          */
-        default: 30,
+        default: 17,
       },
     });
 


### PR DESCRIPTION
Removed the part when the `transfer` method tries to send directly with the token from the 'from' address.

Leaving attempting with the destination's token directly. The `checkSendLimit` call from the hub will return 0 if the destination is an organization, and it will return the source balance of the token otherwise. We are safe because anyone can receive any quantity of their own tokens.

Also, reduce default pathfinderMaxTransferSteps to be safe in the size of the tx data.